### PR TITLE
Export additional modules from index file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
-export * as Commands from './commands/indexDocs';
-import { Client } from './client';
 export * as Util from './util';
-import { Connection } from './connection';
-import { Priority } from './logcat';
+export * as Commands from './commands/indexDocs';
 
-export { Client, Connection, Priority };
+export { Client } from './client';
+export { Device } from './device';
+export { Tracker } from './tracker';
+export { Priority } from './logcat';
+export { Connection } from './connection';  


### PR DESCRIPTION
Types of classes that are not exported may need to be defined in TypeScript projects.