### PR TITLE
Keep logcat stream alive

### DIFF
--- a/src/commands/host-transport/logcat.ts
+++ b/src/commands/host-transport/logcat.ts
@@ -9,7 +9,7 @@ import TransportCommand from '../abstract/transport';
 export default class LogcatCommand extends TransportCommand<LogcatReader> {
     private options: LogcatOptions | void;
     protected Cmd = 'shell:echo && ';
-    protected keepAlive = false;
+    protected keepAlive = true;
 
     constructor(
         connection: Connection,


### PR DESCRIPTION
Logcat stream was closed once no logs were available. It should remained open until closed explicitly.